### PR TITLE
fix js scroll

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,10 +3,14 @@
         .domain([0, 1])
         .range([0, 2]);
 
-    const viewportHeight = window.innerHeight;
-    const scrollDistance = viewportHeight * 0.75;
-
-    scrollIt(scrollDistance, 2000);
+    // reset scroll on refresh
+    window.scroll(0,0);
+    // scroll to first headline
+    const {top} = document.querySelector(".header__section").getBoundingClientRect()
+    window.scrollTo({
+        top: top * 0.8,
+        behavior: "smooth",
+    })
 
     let introObserver = enterView({
         selector: '.header__title, .header__text',
@@ -29,45 +33,3 @@
     });
 
 })();
-
-// code credits to Pawel Grzybek: https://pawelgrzybek.com/page-scroll-in-vanilla-javascript/
-function scrollIt(destination, duration, callback) {
-
-    const start = window.pageYOffset;
-    const startTime = 'now' in window.performance ? performance.now() : new Date().getTime();
-
-    const documentHeight = Math.max(document.body.scrollHeight, document.body.offsetHeight, document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight);
-    const windowHeight = window.innerHeight || document.documentElement.clientHeight || document.getElementsByTagName('body')[0].clientHeight;
-    const destinationOffset = typeof destination === 'number' ? destination : destination.offsetTop;
-    const destinationOffsetToScroll = Math.round(documentHeight - destinationOffset < windowHeight ? documentHeight - windowHeight : destinationOffset);
-
-    if ('requestAnimationFrame' in window === false) {
-        window.scroll(0, destinationOffsetToScroll);
-        if (callback) {
-            callback();
-        }
-        return;
-    }
-
-    function scroll() {
-        const now = 'now' in window.performance ? performance.now() : new Date().getTime();
-        const time = Math.min(1, ((now - startTime) / duration));
-        const timeFunction = easeOutQuart(time);
-        window.scroll(0, Math.ceil((timeFunction * (destinationOffsetToScroll - start)) + start));
-
-        if (window.pageYOffset === destinationOffsetToScroll) {
-            if (callback) {
-                callback();
-            }
-            return;
-        }
-
-        requestAnimationFrame(scroll);
-    }
-
-    function easeOutQuart(t) {
-        return 1 - (--t) * t * t * t;
-    }
-
-    scroll();
-}


### PR DESCRIPTION
Hi guys, I tried to see why the page was stuck in Chrome. 
It seems the reason was that a function in `main.js` that was managing the scroll position on loading stopped working with a newer version of Chrome.

I decided to remove it entirely because it seemed an overkill for what it was doing (and also buggy). Now a much simpler version just scrolls to the first headline on page load. At least now the page should function correctly on Chrome desktops (I don't think it never properly worked on mobile phones)

Let me know if this could be a solution! This should fix #11 

Ciao =)